### PR TITLE
fix: search for letter 'A' variants 

### DIFF
--- a/src/services/Glyphs.js
+++ b/src/services/Glyphs.js
@@ -57,7 +57,7 @@ export default new class {
             .replace('-B', ''),
           item.name
             .replace(/-[0-9]/g, '')
-            .replace(' a ', '')
+            .replace(/(?<!letter) a /g,'')
             .replace(' an ', ''),
         ].join(' '),
       }

--- a/src/services/Glyphs.js
+++ b/src/services/Glyphs.js
@@ -57,8 +57,8 @@ export default new class {
             .replace('-B', ''),
           item.name
             .replace(/-[0-9]/g, '')
-            .replace(/(?<!letter) a /g,'')
-            .replace(' an ', ''),
+            .replace(/(?<!letter) a /g, ' ')
+            .replace(' an ', ' '),
         ].join(' '),
       }
     })


### PR DESCRIPTION
Fix for #84.

2 changes in creation of search index:
1. When cleaning the glyph name, instead of replacing the literal string ' a ', use a regex to only replace ' a ' when it's not preceded by 'letter'.
This ensures that 'a' is added to the index as a keyword for a glyph when its name contains "letter a":
e.g., `latin small letter a with grave`
…while still excluding 'a' as a keyword for glyph names that use 'a' as an indefinite article:
e.g., `x in a rectangle box`
The result is then consistent with other letter glyphs.

2. When replacing ' a ' or ' an ', replace with a single space instead of blank to preserve the boundary between the remaining words.
Thus `x in a rectangle box` will be added to the index as `x in rectangle box` instead of `x inrectangle box`, and this glyph can then be found by searching for 'rectangle'.

Note this change does not affect handling of glyphs with "linear a" in their name, which while not an indefinite article usage, seems to be the desired behavior.